### PR TITLE
Fix matrix inversion function for matrix4

### DIFF
--- a/matrices/matrix4.lisp
+++ b/matrices/matrix4.lisp
@@ -341,7 +341,7 @@
 (declaim (ftype (function (mat4) mat4) inverse-matrix))
 (defun inverse (matrix)
   (let ((det (m4:determinant matrix)))
-    (if (= det 0s0)
+    (if (cl:= det 0s0)
         (error "Cannot invert matrix with zero determinant:~%  ~S"
                matrix)
         (macrolet ((a (x y z)


### PR DESCRIPTION
There was a comparison between determinant and a zero
which used = defined in matrix4.lisp rather than cl:=
