### PR TITLE
Fix typo in #'m2-n:set-rotation-from-euler

### DIFF
--- a/matrices/matrix2/non-consing.lisp
+++ b/matrices/matrix2/non-consing.lisp
@@ -92,8 +92,8 @@
   (declare (optimize (speed 3) (safety 1) (debug 1)))
   (let ((sa (sin angle))
         (ca (cos angle)))
-    (set-components ca sa
-                    (cl:- sa) ca
+    (set-components ca (cl:- sa)
+                    sa ca
                     mat-to-mutate)))
 
 ;;----------------------------------------------------------------


### PR DESCRIPTION
Looks like rotation coefficients were transposed.