### PR TITLE
fixed abs coordinate bug that used y a second time instead of z

### DIFF
--- a/vectors/vector3/consing.lisp
+++ b/vectors/vector3/consing.lisp
@@ -275,7 +275,7 @@
   (declare (optimize (speed 3) (safety 1) (debug 1)))
   (make (cl:abs (x vector-a))
         (cl:abs (y vector-a))
-        (cl:abs (y vector-a))))
+        (cl:abs (z vector-a))))
 
 ;;---------------------------------------------------------------
 


### PR DESCRIPTION
In the v3:abs function, y was used a second time where z should have been used for the z coordinate